### PR TITLE
Add Python 3.10 to the build matrix

### DIFF
--- a/strategy.json
+++ b/strategy.json
@@ -1,6 +1,6 @@
 {
   "matrix": {
     "os": ["macos-latest", "ubuntu-latest", "windows-latest"],
-    "python": [3.6, 3.7, 3.8, 3.9]
+    "python": [3.6, 3.7, 3.8, 3.9, 3.10]
   }
 }


### PR DESCRIPTION
Python 3.10 was released in October and is the current stable version of Python 3.