### PR TITLE
Represent Python versions as strings

### DIFF
--- a/strategy.json
+++ b/strategy.json
@@ -1,6 +1,6 @@
 {
   "matrix": {
     "os": ["macos-latest", "ubuntu-latest", "windows-latest"],
-    "python": [3.6, 3.7, 3.8, 3.9, 3.10]
+    "python": ["3.6", "3.7", "3.8", "3.9", "3.10"]
   }
 }


### PR DESCRIPTION
Somewhere along the way, the trailing zero is getting dropped from `3.10`.