### PR TITLE
Add a canary build for this repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: Run tests
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      strategy: ${{steps.load.outputs.strategy}}
+
+    steps:
+      - uses: actions/checkout@v2
+      - id: load
+        run: echo "::set-output name=strategy::$(echo $(cat strategy.json))"
+
+  canary:
+    needs: [setup]
+    strategy: ${{fromJson(needs.setup.outputs.strategy)}}
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Choose colcon-notification for a canary build. It has colcon
+          # dependencies and debian patches, so exercieses a fair amount of the
+          # CI action features.
+          repository: colcon/colcon-notification
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{matrix.python}}
+      - uses: actions/checkout@v2
+        with:
+          path: colcon_ci
+      - uses: ./colcon_ci/


### PR DESCRIPTION
This change adds pull request testing on this GitHub Action by invoking itself on a designated "canary" package.

The chosen package is `colcon-notification`, because:
1. It is supported on all platforms
2. It has a dependency on another colcon package (colcon-core)
3. It has a `debian` subdirectory for applying patches

These qualities mean that it covers a fair amount of the features of this Action.