### PR TITLE
Run publish-python to test release workflow

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,3 +27,21 @@ runs:
         echo ::group::Run tests
         python -m pytest --cov --cov-branch --cov-report xml:coverage.xml --cov-config setup.cfg
         echo ::endgroup::
+
+        echo ::group::Test publish
+        # Run publish-python without uploading the results
+        if [ -f publish-python.yaml ]; then
+          PUBLISH_PYTHON=$(mktemp -d)
+          git clone https://github.com/dirk-thomas/publish-python.git $PUBLISH_PYTHON
+          python -m pip install -U PyYAML wheel
+          python $PUBLISH_PYTHON/bin/publish-python wheel:pypi
+          if [ -f /etc/debian_version ]; then
+            sudo apt install -y debhelper dh-python fakeroot python3-all python3-stdeb python3-yaml
+            DEB_BUILD_OPTIONS=nocheck /usr/bin/python3 $PUBLISH_PYTHON/bin/publish-python stdeb:packagecloud
+          else
+            echo "Skipping stdeb test on non-Debian platform..."
+          fi
+        else
+          echo "Repository not configured - Skipping..."
+        fi
+        echo ::endgroup::


### PR DESCRIPTION
On several occasions, changes to the `setup.cfg` of a colcon package have resulted in the Debian patch failing to apply. To avoid that in the future, we should run `publish-python` to validate the release workflow as part of CI.

Since the Debian part of that workflow will only work on Debian or Ubuntu, only run that part there.