### PR TITLE
Start testing colcon packages against Python 3.11

### DIFF
--- a/strategy.json
+++ b/strategy.json
@@ -1,6 +1,6 @@
 {
   "matrix": {
     "os": ["macos-latest", "ubuntu-latest", "windows-latest"],
-    "python": ["3.6", "3.7", "3.8", "3.9", "3.10"]
+    "python": ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
   }
 }


### PR DESCRIPTION
Python 3.11 has been released, and we should test all future colcon changes against it.