### PR TITLE
Pin Python 3.6 testing to Ubuntu Focal

### DIFF
--- a/strategy.json
+++ b/strategy.json
@@ -1,6 +1,12 @@
 {
   "matrix": {
     "os": ["macos-latest", "ubuntu-latest", "windows-latest"],
-    "python": ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+    "python": ["3.7", "3.8", "3.9", "3.10", "3.11"],
+    "include": [
+      {
+        "os": "ubuntu-20.04",
+	"python": "3.6"
+      }
+    ]
   }
 }

--- a/strategy.json
+++ b/strategy.json
@@ -5,7 +5,7 @@
     "include": [
       {
         "os": "ubuntu-20.04",
-	"python": "3.6"
+        "python": "3.6"
       }
     ]
   }


### PR DESCRIPTION
The `ubuntu-latest` label is moving forward to target Jammy, which doesn't have support for Python 3.6.

Note that this will drop Python 3.6 testing from Darwin and Windows - I think this is actually a good thing. The only reason we're running Python 3.6 tests anymore is for RHEL 8.