### PR TITLE
Select which platforms check stdeb using matrix

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ runs:
           git clone https://github.com/dirk-thomas/publish-python.git $PUBLISH_PYTHON
           python -m pip install -U PyYAML wheel
           python $PUBLISH_PYTHON/bin/publish-python wheel:pypi
-          if [ -f /etc/debian_version ]; then
+          if [ ! -z "${{matrix.stdeb-check}}" ]; then
             sudo apt install -y debhelper dh-python fakeroot python3-all python3-stdeb python3-yaml
             DEB_BUILD_OPTIONS=nocheck /usr/bin/python3 $PUBLISH_PYTHON/bin/publish-python stdeb:packagecloud
           else

--- a/strategy.json
+++ b/strategy.json
@@ -6,6 +6,10 @@
       {
         "os": "ubuntu-20.04",
         "python": "3.6"
+      },
+      {
+        "os": "ubuntu-latest",
+        "stdeb-check": "1"
       }
     ]
   }


### PR DESCRIPTION
This change makes the `publish-python` stdeb check run based on the matrix configuration instead of checking whether the platform is Debian-based.

This will allow us to configure which Ubuntu platforms we actually run the check for. For now, we'll run it only on any matrix entries running on `ubuntu-latest`.