### PR TITLE
Support building colcon extensions with no setup.py

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -17,9 +17,14 @@ runs:
         python -m pip install -U pip setuptools
         echo ::endgroup::
 
+        echo ::group::Install package
+        python -m pip install -U -e .[test] --no-deps
+        echo ::endgroup::
+
         echo ::group::Install dependencies
         # Remove this package from constraints
-        grep -v "^$(python setup.py --name)@" ${GITHUB_ACTION_PATH}/constraints.txt > constraints.txt
+        PKG_NAME=$(pip list --local --editable --format json | jq '.[0].name' -r)
+        grep -v "^${PKG_NAME}@" ${GITHUB_ACTION_PATH}/constraints.txt > constraints.txt
         # Install dependencies, including any 'test' extras, as well as pytest-cov
         python -m pip install -U -e .[test] pytest-cov -c constraints.txt
         echo ::endgroup::


### PR DESCRIPTION
~~This change uses a pip "download" operation to read the name of the package being built so that it can be removed from the constraints.txt prior to downloading dependencies.~~

This change separates the installation of the package being tested from the installation of its dependencies. After initial installation, the package's name is found using `pip list` and excluded from the org-level constraints file that's used to ensure that HEAD is used for each of those repositories.

The package name must be removed from constraints.txt or pip will fail to install the package and its dependencies due to the conflict.

Note that pytest-cov still requires a setup.cfg to be present - storing coverage information in pyproject.toml is not yet supported by this action.

---

I could find no better way to get pip to output the local package name than to invoke a "dummy" download operation like this. If anyone has a better idea how to reliably get the package name or avoid the constraints.txt conflict, I'd love to see it.