### PR TITLE
Add Python 3.12 to the test matrix

### DIFF
--- a/strategy.json
+++ b/strategy.json
@@ -1,7 +1,7 @@
 {
   "matrix": {
     "os": ["macos-latest", "ubuntu-latest", "windows-latest"],
-    "python": ["3.7", "3.8", "3.9", "3.10", "3.11"],
+    "python": ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"],
     "include": [
       {
         "os": "ubuntu-20.04",


### PR DESCRIPTION
Python 3.12 was released in October of 2023.