### PR TITLE
Introduce a workflow_call reusable workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,32 +6,10 @@ on:
   pull_request:
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      strategy: ${{steps.load.outputs.strategy}}
-
-    steps:
-      - uses: actions/checkout@v3
-      - id: load
-        run: echo "strategy=$(echo $(cat strategy.json))" >> $GITHUB_OUTPUT
-
   canary:
-    needs: [setup]
-    strategy: ${{fromJson(needs.setup.outputs.strategy)}}
-    runs-on: ${{matrix.os}}
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # Choose colcon-notification for a canary build. It has colcon
-          # dependencies and debian patches, so exercieses a fair amount of the
-          # CI action features.
-          repository: colcon/colcon-notification
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{matrix.python}}
-      - uses: actions/checkout@v3
-        with:
-          path: colcon_ci
-      - uses: ./colcon_ci/
+    uses: ./.github/workflows/pytest.yaml
+    with:
+      # Choose colcon-notification for a canary build. It has colcon
+      # dependencies and debian patches, so exercieses a fair amount of the
+      # CI action features.
+      repository: colcon/colcon-notification

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,46 @@
+name: Run tests
+
+on:
+  workflow_call:
+    inputs:
+      codecov:
+        description: 'run codecov action after testing'
+        default: false
+        required: false
+        type: boolean
+      matrix-filter:
+        description: 'jq filter string indicating which configuration(s) should be included'
+        default: '.'
+        required: false
+        type: string
+      repository:
+        description: 'repository to test if different from current'
+        default: ''
+        required: false
+        type: string
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      strategy: ${{ steps.load.outputs.strategy }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: load
+        run: echo "strategy=$(jq -c -M '${{ inputs.matrix-filter }}' strategy.json)" >> $GITHUB_OUTPUT
+
+  pytest:
+    needs: [setup]
+    strategy: ${{ fromJson(needs.setup.outputs.strategy) }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: cottsay/colcon-ci@main
+      - uses: codecov/codecov-action@v3
+        if: ${{ inputs.codecov }}


### PR DESCRIPTION
This change significantly reduces the amount of boiler plate needed in each colcon repository to get unified CI with a centralized matrix. The new files will be only 10 lines long, and will no longer have any actions versions that need to be kept up-to-date.

The `ci.yaml` in this change is similar to how individual repositories will look.