### PR TITLE
Fix error detection in bash command substitution

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,7 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: load
-        run: echo "strategy=$(jq -c -M '${{ inputs.matrix-filter }}' strategy.json)" >> $GITHUB_OUTPUT
+        run: |
+          strategy=$(jq -c -M '${{ inputs.matrix-filter }}' strategy.json)
+          echo "strategy=${strategy}" >> $GITHUB_OUTPUT
 
   pytest:
     needs: [setup]


### PR DESCRIPTION
GitHub Actions runs bash with `-e` by default, but because we were combining the command substitution with an echo, the return code from the subshell was ignored.

Capturing the command substitution explicitly should resolve the issue.