### PR TITLE
Fix reference to strategy.json when run from other repos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,3 +13,5 @@ jobs:
       # dependencies and debian patches, so exercieses a fair amount of the
       # CI action features.
       repository: colcon/colcon-notification
+      # Use HEAD to find strategy.json file instead of the tip of colcon/ci
+      setup-repository: ''

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -18,6 +18,11 @@ on:
         default: ''
         required: false
         type: string
+      setup-repository:
+        description: 'repository used during job setup'
+        default: 'colcon/ci'
+        required: false
+        type: string
 
 jobs:
   setup:
@@ -26,6 +31,8 @@ jobs:
       strategy: ${{ steps.load.outputs.strategy }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.setup-repository }}
       - id: load
         run: echo "strategy=$(jq -c -M '${{ inputs.matrix-filter }}' strategy.json)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The action/checkout action will clone the calling repository by default, where we need the content of colcon/ci. In order to allow PRs into this repository to test changes to strategy.json, I added an override for local CI use.