### PR TITLE
Add dependabot configuration to keep Actions up-to-date

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will leverage Dependabot to open PRs to colcon/ci updating the major versions of individual GitHub Actions.