### PR TITLE
Allow CI to trigger from workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ['main']
   pull_request:
+  workflow_dispatch:
 
 jobs:
   canary:


### PR DESCRIPTION
This should allow us to trigger the CI action on-demand as a "sanity check".

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch