### PR TITLE
Normalize package name detected by pip list

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ runs:
 
         echo ::group::Install dependencies
         # Remove this package from constraints
-        PKG_NAME=$(pip list --local --editable --format json | jq '.[0].name' -r)
+        PKG_NAME=$(pip list -l -e --format json | jq '.[0].name' -r | tr _ -)
         grep -v "^${PKG_NAME}@" ${GITHUB_ACTION_PATH}/constraints.txt > constraints.txt
         # Install dependencies, including any 'test' extras, as well as pytest-cov
         python -m pip install -U -e .[test] pytest-cov -c constraints.txt


### PR DESCRIPTION
Modern Python (or setuptools?) versions no longer normalize package names during installation. This isn't a problem in any of the current colcon packages, but if any are ever introduced which contain an underscore, normalization will be necessary to ensure that we properly detect the package name on all supported Python versions in the matrix.

Requires #23 to actually be tested by CI