### PR TITLE
Drop EOL Python 3.7 from the testing matrix

### DIFF
--- a/strategy.json
+++ b/strategy.json
@@ -1,7 +1,7 @@
 {
   "matrix": {
     "os": ["macos-latest", "ubuntu-latest", "windows-latest"],
-    "python": ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"],
+    "python": ["3.8", "3.9", "3.10", "3.11", "3.12"],
     "include": [
       {
         "os": "ubuntu-20.04",


### PR DESCRIPTION
The `macos-latest` runners don't consistently support Python 3.7 any longer.