### PR TITLE
Allow use of CODECOV_TOKEN to enable codecov upload

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -25,6 +25,10 @@ on:  # yamllint disable-line rule:truthy
         default: 'colcon/ci'
         required: false
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        description: 'token to use when running codecov action after testing'
+        required: false
 
 jobs:
   setup:
@@ -59,3 +63,7 @@ jobs:
       - uses: ./.github-ci-action-repo
       - uses: codecov/codecov-action@v3
         if: ${{ inputs.codecov }}
+      - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: ${{ env.CODECOV_TOKEN != '' }}


### PR DESCRIPTION
This will replace the existing:
```yaml
  with:
    codecov: true
```

...with...

```yaml
  secrets:
    CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
```

...and will require users to set the `CODECOV_TOKEN` secret in their repository secrets.

Canary: https://github.com/colcon/colcon-core/pull/648/files