### PR TITLE
Use 'null' for default CODECOV_TOKEN

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -48,6 +48,8 @@ jobs:
     needs: [setup]
     strategy: ${{ fromJson(needs.setup.outputs.strategy) }}
     runs-on: ${{ matrix.os }}
+    env:
+      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), 'CODECOV_TOKEN') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -66,4 +68,4 @@ jobs:
       - uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ env.HAVE_CODECOV_TOKEN == 'true' }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy: ${{ fromJson(needs.setup.outputs.strategy) }}
     runs-on: ${{ matrix.os }}
     env:
-      HAVE_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != null }}
+      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), 'CODECOV_TOKEN') }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy: ${{ fromJson(needs.setup.outputs.strategy) }}
     runs-on: ${{ matrix.os }}
     env:
-      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), '"CODECOV_TOKEN":') }}
+      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), '"CODECOV_TOKEN"') }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy: ${{ fromJson(needs.setup.outputs.strategy) }}
     runs-on: ${{ matrix.os }}
     env:
-      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), '"CODECOV_TOKEN"') }}
+      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), 'CODECOV_TOKEN') }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy: ${{ fromJson(needs.setup.outputs.strategy) }}
     runs-on: ${{ matrix.os }}
     env:
-      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), "'CODECOV_TOKEN':") }}
+      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), '"CODECOV_TOKEN":') }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy: ${{ fromJson(needs.setup.outputs.strategy) }}
     runs-on: ${{ matrix.os }}
     env:
-      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), 'CODECOV_TOKEN') }}
+      HAVE_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != null }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy: ${{ fromJson(needs.setup.outputs.strategy) }}
     runs-on: ${{ matrix.os }}
     env:
-      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), 'CODECOV_TOKEN') }}
+      HAVE_CODECOV_TOKEN: ${{ contains(toJson(secrets), "'CODECOV_TOKEN':") }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The intent here is that specifying a CODECOV_TOKEN, even an empty one, should still trigger the step.