### PR TITLE
Drop codecov-action@v3, enable codecov by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
   canary:
     uses: ./.github/workflows/pytest.yaml
     with:
+      codecov: false
       # Choose colcon-notification for a canary build. It has colcon
       # dependencies and debian patches, so exercieses a fair amount of the
       # CI action features.

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,7 +6,7 @@ on:  # yamllint disable-line rule:truthy
     inputs:
       codecov:
         description: 'run codecov action after testing'
-        default: false
+        default: true
         required: false
         type: boolean
       matrix-filter:
@@ -61,9 +61,7 @@ jobs:
           repository: ${{ inputs.setup-repository }}
           path: ./.github-ci-action-repo
       - uses: ./.github-ci-action-repo
-      - uses: codecov/codecov-action@v3
-        if: ${{ inputs.codecov }}
       - uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ inputs.codecov }}


### PR DESCRIPTION
Two reasons to do this:
1. We should really be tracking our coverage better in colcon. Some of the critical path repos have zero tests.
2. Relying on the `CODECOV_TOKEN` secret being non-empty means that PRs from forks don't get coverage uploads, so comparing with `''` was never the correct thing to do anyway.

Repositories can still opt out of coverage, but because we're going to want this on nearly all of the repositories anyway, we should just make it the default.