### PR TITLE
Add initialization step

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -25,6 +25,11 @@ on:  # yamllint disable-line rule:truthy
         default: 'colcon/ci'
         required: false
         type: string
+      prerun-step:
+        description: 'instruction to run before the testing'
+        default: ''
+        required: false
+        type: string
     secrets:
       CODECOV_TOKEN:
         description: 'token to use when running codecov action after testing'
@@ -53,6 +58,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
+      - run: bash -c "${{ inputs.prerun-step }}"
+        if: ${{ inputs.prerun-step != ''}}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
Certain downstream repos might need an initialization step to be ran before the workflow itself.
Reusable workflows [cannot be executed as a step](https://stackoverflow.com/questions/75733616/github-actions-how-to-call-a-reusable-workflow-as-a-step) so adding a step in the downstream repo is not possible (I believe?), so I tried the approach of allowing command injection by specifying an input variable that is executed as a bash command. The step is ignored if no command is specified.

Example of usage in https://github.com/colcon/colcon-ros-cargo/pull/22. `colcon-ros-cargo` needs to run `cargo install cargo-ament-build` before it can run its CI, so we inject it into the `prerun-step` variable and that allows us to setup the workflow correctly.

Note that I'm not sure there is a better way to add a setup step before running a reusable workflow, I saw threads suggesting using a local action but didn't have much luck with it, open to suggestions if there are better ways!