### PR TITLE
Pin wheel<0.46 for bdist_wheel command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -44,7 +44,7 @@ runs:
           pushd $PUBLISH_PYTHON
           git clone https://github.com/colcon/publish-python.git .
           popd
-          python -m pip install -U PyYAML wheel
+          python -m pip install -U PyYAML 'wheel<0.46'
           python $PUBLISH_PYTHON/bin/publish-python wheel:pypi
           if [ ! -z "${{matrix.stdeb-check}}" ]; then
             sudo apt install \


### PR DESCRIPTION
Evidently this should now be provided by setuptools, but we're in a mixed state because we're typically using the system's setuptools which may be older.