### PR TITLE
Drop Ubuntu 20.04 / Python 3.6 test

### DIFF
--- a/strategy.json
+++ b/strategy.json
@@ -4,10 +4,6 @@
     "python": ["3.8", "3.9", "3.10", "3.11", "3.12"],
     "include": [
       {
-        "os": "ubuntu-20.04",
-        "python": "3.6"
-      },
-      {
         "os": "ubuntu-22.04",
         "stdeb-check": "1"
       }


### PR DESCRIPTION
We no longer have a viable native platform for running Linux tests for Python 3.6, as Ubuntu 20.04 has been removed.